### PR TITLE
Update to Python 3

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@
 import os
 
 from flask import Flask, render_template
-import oursql
+import MySQLdb
 
 app = Flask(__name__)
 app.debug = True
@@ -25,7 +25,7 @@ def index():
         f.write(str(hit_count) + '\n')
 
     # Test database connection
-    conn = oursql.connect(host='127.0.0.1', user='root', passwd="")
+    conn = MySQLdb.connect(host='localhost', user='root', passwd="")
     curs = conn.cursor()
     curs.execute("SELECT 1 + 1")
     dbresult = curs.fetchone()
@@ -33,4 +33,4 @@ def index():
     return render_template("index.html", hit_count=hit_count, dbresult=dbresult)
 
 application = app.wsgi_app
-print "Prepared."
+print("Prepared.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Flask
-oursql
+Flask-MySQLdb


### PR DESCRIPTION
Okay, this is to work with the Bullseye branch of vagrant-spk, and will be merged simultaneously! I had a lot of difficulty getting oursql3 to work, even though they allegedly fixed the errors I was seeing. I believe it had some justification for being better than MySQLdb, but it surely isn't important for our test app or default configuration. Note that the sample app's own text also explicitly says 127.0.0.1 doesn't work but localhost does. I found this true in my testing with the MySQLdb plugin as well.